### PR TITLE
do not invoke next.Close when connection not established

### DIFF
--- a/pkg/networkservice/l2ovsconnect/client.go
+++ b/pkg/networkservice/l2ovsconnect/client.go
@@ -47,7 +47,10 @@ func (c *l2ConnectClient) Request(ctx context.Context, request *networkservice.N
 
 	postponeCtxFunc := postpone.ContextWithValues(ctx)
 
-	isEstablished := request.GetConnection().GetNextPathSegment() != nil
+	var isEstablished bool
+	if endpointOvsPortInfo, exists := ifnames.Load(ctx, false); exists {
+		isEstablished = endpointOvsPortInfo.IsCrossConnected
+	}
 
 	conn, err := next.Client(ctx).Request(ctx, request, opts...)
 	if err != nil || isEstablished {

--- a/pkg/networkservice/l2ovsconnect/local.go
+++ b/pkg/networkservice/l2ovsconnect/local.go
@@ -51,6 +51,10 @@ func createLocalCrossConnect(logger log.Logger, bridgeName string, endpointOvsPo
 		logger.Errorf("Failed to add flow on %s for port %s stdout: %s"+
 			" stderr: %s", bridgeName, clientOvsPortInfo.PortName, stdout, stderr)
 	}
+
+	endpointOvsPortInfo.IsCrossConnected = true
+	clientOvsPortInfo.IsCrossConnected = true
+
 	return nil
 }
 

--- a/pkg/networkservice/l2ovsconnect/remote.go
+++ b/pkg/networkservice/l2ovsconnect/remote.go
@@ -71,6 +71,9 @@ func createRemoteCrossConnect(logger log.Logger, bridgeName string, endpointOvsP
 			" stderr: %s", bridgeName, ovsTunnelPort, stdout, stderr)
 	}
 
+	endpointOvsPortInfo.IsCrossConnected = true
+	clientOvsPortInfo.IsCrossConnected = true
+
 	return nil
 }
 

--- a/pkg/networkservice/mechanisms/kernel/smartvf_server.go
+++ b/pkg/networkservice/mechanisms/kernel/smartvf_server.go
@@ -60,9 +60,10 @@ func (k *kernelSmartVFServer) Request(ctx context.Context, request *networkservi
 	if err != nil && !isEstablished {
 		closeCtx, cancelClose := postponeCtxFunc()
 		defer cancelClose()
-
-		if _, closeErr := k.Close(closeCtx, conn); closeErr != nil {
-			err = errors.Wrapf(err, "connection closed with error: %s", closeErr.Error())
+		if ovsPortInfo, exists := ifnames.LoadAndDelete(closeCtx, metadata.IsClient(k)); exists {
+			if kernelServerErr := resetVF(logger, ovsPortInfo, k.bridgeName); kernelServerErr != nil {
+				err = errors.Wrapf(err, "connection closed with error: %s", kernelServerErr.Error())
+			}
 		}
 		return nil, err
 	}

--- a/pkg/networkservice/mechanisms/kernel/smartvf_server.go
+++ b/pkg/networkservice/mechanisms/kernel/smartvf_server.go
@@ -47,7 +47,7 @@ func NewSmartVFServer(bridgeName string) networkservice.NetworkServiceServer {
 func (k *kernelSmartVFServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
 	logger := log.FromContext(ctx).WithField("kernelSmartVFServer", "Request")
 
-	isEstablished := request.GetConnection().GetNextPathSegment() != nil
+	_, isEstablished := ifnames.Load(ctx, metadata.IsClient(k))
 	if !isEstablished {
 		if vfErr := setupVF(ctx, logger, request.GetConnection(), k.bridgeName, metadata.IsClient(k)); vfErr != nil {
 			return nil, vfErr

--- a/pkg/networkservice/mechanisms/vxlan/client.go
+++ b/pkg/networkservice/mechanisms/vxlan/client.go
@@ -29,10 +29,13 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/vxlan/vni"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
 	"github.com/networkservicemesh/sdk/pkg/tools/postpone"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+
+	"github.com/networkservicemesh/sdk-ovs/pkg/tools/ifnames"
 )
 
 type vxlanClient struct {
@@ -59,7 +62,7 @@ func (c *vxlanClient) Request(ctx context.Context, request *networkservice.Netwo
 		Type: vxlan.MECHANISM,
 	})
 
-	isEstablished := request.GetConnection().GetNextPathSegment() != nil
+	_, isEstablished := ifnames.Load(ctx, metadata.IsClient(c))
 
 	postponeCtxFunc := postpone.ContextWithValues(ctx)
 

--- a/pkg/networkservice/mechanisms/vxlan/server.go
+++ b/pkg/networkservice/mechanisms/vxlan/server.go
@@ -71,9 +71,10 @@ func (v *vxlanServer) Request(ctx context.Context, request *networkservice.Netwo
 	if err != nil && !isEstablished {
 		closeCtx, cancelClose := postponeCtxFunc()
 		defer cancelClose()
-
-		if _, closeErr := v.Close(closeCtx, conn); closeErr != nil {
-			err = errors.Wrapf(err, "connection closed with error: %s", closeErr.Error())
+		if _, exists := ifnames.LoadAndDelete(closeCtx, metadata.IsClient(v)); exists {
+			if vxlanServerErr := remove(request.GetConnection(), v.bridgeName, v.vxlanInterfacesMutex, v.vxlanInterfacesMap, metadata.IsClient(v)); vxlanServerErr != nil {
+				err = errors.Wrapf(err, "connection closed with error: %s", vxlanServerErr.Error())
+			}
 		}
 		return nil, err
 	}

--- a/pkg/networkservice/mechanisms/vxlan/server.go
+++ b/pkg/networkservice/mechanisms/vxlan/server.go
@@ -57,7 +57,7 @@ func NewServer(tunnelIP net.IP, bridgeName string, mutex sync.Locker, vxlanRefCo
 func (v *vxlanServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
 	logger := log.FromContext(ctx).WithField("vxlanServer", "Request")
 
-	isEstablished := request.GetConnection().GetNextPathSegment() != nil
+	_, isEstablished := ifnames.Load(ctx, metadata.IsClient(v))
 
 	if !isEstablished {
 		if err := add(ctx, logger, request.GetConnection(), v.bridgeName, v.vxlanInterfacesMutex, v.vxlanInterfacesMap, metadata.IsClient(v)); err != nil {

--- a/pkg/tools/ifnames/ifnames.go
+++ b/pkg/tools/ifnames/ifnames.go
@@ -29,11 +29,12 @@ type key struct{}
 
 // OvsPortInfo ovs port info container
 type OvsPortInfo struct {
-	PortName        string
-	PortNo          int
-	IsTunnelPort    bool
-	IsVfRepresentor bool
-	VNI             uint32
+	PortName         string
+	PortNo           int
+	IsTunnelPort     bool
+	IsVfRepresentor  bool
+	IsCrossConnected bool
+	VNI              uint32
 }
 
 // Store stores ovsPortInfo for the given cross connect, isClient identfies which connection it is.


### PR DESCRIPTION
This fixes too many stale interface and ovs port entries upon service request failure  (due to `IP Pool Empty `error).

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>

<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->


## Issue link
<!--- Please link to the issue here. -->


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
