### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,8 +30,6 @@ jobs:
     name: Create release
     needs: get-tag
     uses: networkservicemesh/.github/.github/workflows/release.yaml@main
-    with:
-      tag: ${{ needs.get-tag.outputs.tag }}
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Release workflow doesn't need get-tag job now. It has its own get-tag job.

## PR link
https://github.com/networkservicemesh/.github/pull/26


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [x] CI
