### PR TITLE
Fix interface cleanup

### DIFF
--- a/pkg/networkservice/l2ovsconnect/client.go
+++ b/pkg/networkservice/l2ovsconnect/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Nordix Foundation.
+// Copyright (c) 2021-2023 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build linux
+// +build linux
+
 // Package l2ovsconnect chain element which cross connects both client and endpoint.
 // This suppports both local and remote (vxlan) cross connections.
 package l2ovsconnect
@@ -23,6 +26,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/vfconfig"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
@@ -76,6 +80,7 @@ func (c *l2ConnectClient) Close(ctx context.Context, conn *networkservice.Connec
 
 	l2ConnectErr := addDel(ctx, logger, conn, c.bridgeName, false)
 	ifnames.Delete(ctx, metadata.IsClient(c))
+	vfconfig.Delete(ctx, metadata.IsClient(c))
 
 	if err != nil && l2ConnectErr != nil {
 		return nil, errors.Wrap(err, l2ConnectErr.Error())

--- a/pkg/networkservice/l2ovsconnect/local.go
+++ b/pkg/networkservice/l2ovsconnect/local.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Nordix Foundation.
+// Copyright (c) 2021-2023 Nordix Foundation.
 //
 // Copyright (c) 2023 Cisco and/or its affiliates.
 //
@@ -15,6 +15,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//go:build linux
+// +build linux
 
 package l2ovsconnect
 
@@ -53,6 +56,8 @@ func createLocalCrossConnect(logger log.Logger, bridgeName string, endpointOvsPo
 	if stderr != "" {
 		logger.Errorf("Failed to add flow on %s for port %s stdout: %s"+
 			" stderr: %s", bridgeName, endpointOvsPortInfo.PortName, stdout, stderr)
+	} else {
+		logger.Debugf("Flow added on %s for port %s", bridgeName, endpointOvsPortInfo.PortName)
 	}
 
 	stdout, stderr, err = util.RunOVSOfctl("add-flow", "-OOpenflow13", bridgeName, ofRuleToEndpoint)
@@ -65,6 +70,8 @@ func createLocalCrossConnect(logger log.Logger, bridgeName string, endpointOvsPo
 	if stderr != "" {
 		logger.Errorf("Failed to add flow on %s for port %s stdout: %s"+
 			" stderr: %s", bridgeName, clientOvsPortInfo.PortName, stdout, stderr)
+	} else {
+		logger.Debugf("Flow added on %s for port %s", bridgeName, clientOvsPortInfo.PortName)
 	}
 
 	endpointOvsPortInfo.IsCrossConnected = true
@@ -87,11 +94,14 @@ func deleteLocalCrossConnect(logger log.Logger, bridgeName string, endpointOvsPo
 			"%s, stdout: %q, stderr: %q, error: %v", bridgeName, endpointOvsPortInfo.PortName, stdout, stderr, err)
 		return errors.Wrapf(err, "failed to delete flow on %s for port %s, stdout: %q, stderr: %q", bridgeName, endpointOvsPortInfo.PortName, stdout, stderr)
 	}
+	logger.Debugf("Flow deleted on %s for port %s", bridgeName, endpointOvsPortInfo.PortName)
 
 	stdout, stderr, err = util.RunOVSOfctl("del-flows", "-OOpenflow13", bridgeName, fmt.Sprintf("in_port=%d", clientOvsPortInfo.PortNo))
 	if err != nil {
 		logger.Errorf("Failed to delete flow on %s for port "+
 			"%s, stdout: %q, stderr: %q, error: %v", bridgeName, clientOvsPortInfo.PortName, stdout, stderr, err)
+	} else {
+		logger.Debugf("Flow deleted on %s for port %s", bridgeName, &clientOvsPortInfo.PortName)
 	}
 	return nil
 }

--- a/pkg/networkservice/l2ovsconnect/remote.go
+++ b/pkg/networkservice/l2ovsconnect/remote.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Nordix Foundation.
+// Copyright (c) 2021-2023 Nordix Foundation.
 //
 // Copyright (c) 2023 Cisco and/or its affiliates.
 //
@@ -15,6 +15,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//go:build linux
+// +build linux
 
 package l2ovsconnect
 
@@ -69,6 +72,8 @@ func createRemoteCrossConnect(logger log.Logger, bridgeName string, endpointOvsP
 	if stderr != "" {
 		logger.Errorf("Failed to add flow on %s for port %s stdout: %s"+
 			" stderr: %s", bridgeName, ovsLocalPort, stdout, stderr)
+	} else {
+		logger.Debugf("Flow added on %s for port %s", bridgeName, ovsLocalPort)
 	}
 
 	stdout, stderr, err = util.RunOVSOfctl("add-flow", "-OOpenflow13", bridgeName, ofRuleTo)
@@ -81,6 +86,8 @@ func createRemoteCrossConnect(logger log.Logger, bridgeName string, endpointOvsP
 	if stderr != "" {
 		logger.Errorf("Failed to add tunnel flow on %s for port %s stdout: %s"+
 			" stderr: %s", bridgeName, ovsTunnelPort, stdout, stderr)
+	} else {
+		logger.Debugf("Flow added on %s for port %s", bridgeName, ovsTunnelPort)
 	}
 
 	endpointOvsPortInfo.IsCrossConnected = true
@@ -121,13 +128,13 @@ func deleteRemoteCrossConnect(logger log.Logger, bridgeName string, endpointOvsP
 			"%s, stdout: %q, stderr: %q, error: %v", bridgeName, ovsLocalPort, stdout, stderr, err)
 		return errors.Wrapf(err, "Failed to delete flow on %s for port %s, stdout: %q, stderr: %q", bridgeName, ovsLocalPort, stdout, stderr)
 	}
-
+	logger.Debugf("Flow deleted on %s for port %s", bridgeName, ovsLocalPort)
 	stdout, stderr, err = util.RunOVSOfctl("del-flows", "-OOpenflow13", bridgeName, fmt.Sprintf("in_port=%d,tun_id=%d", ovsTunnelPortNum, vni))
 	if err != nil {
 		logger.Errorf("Failed to delete flow on %s for port "+
 			"%s on VNI %d, stdout: %q, stderr: %q, error: %v", bridgeName, ovsTunnelPort, vni, stdout, stderr, err)
 		return errors.Wrapf(err, "failed to delete flow on %s for port %s on VNI %d, stdout: %q, stderr: %q", bridgeName, ovsTunnelPort, vni, stdout, stderr)
 	}
-
+	logger.Debugf("Flow deleted on %s for port %s", bridgeName, ovsTunnelPort)
 	return nil
 }

--- a/pkg/networkservice/mechanisms/kernel/client.go
+++ b/pkg/networkservice/mechanisms/kernel/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Nordix Foundation.
+// Copyright (c) 2021-2023 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -110,7 +110,7 @@ func (c *kernelClient) Close(ctx context.Context, conn *networkservice.Connectio
 		if exists {
 			// ovsPortInfo.IsL2Connect is always false for endpoint ovs port
 			if !ovsPortInfo.IsVfRepresentor {
-				kernelMechErr = resetVeth(ctx, logger, conn, c.bridgeName, c.parentIfRefCountMap, c.serviceToparentIfMap, ovsPortInfo.IsL2Connect, metadata.IsClient(c))
+				kernelMechErr = resetVeth(logger, conn, c.bridgeName, c.parentIfRefCountMap, c.serviceToparentIfMap, ovsPortInfo.IsL2Connect, metadata.IsClient(c))
 			} else {
 				kernelMechErr = resetVF(logger, ovsPortInfo, c.parentIfRefCountMap, c.bridgeName, ovsPortInfo.IsL2Connect)
 			}

--- a/pkg/networkservice/mechanisms/kernel/common.go
+++ b/pkg/networkservice/mechanisms/kernel/common.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Nordix Foundation.
+// Copyright (c) 2021-2023 Nordix Foundation.
 //
 // Copyright (c) 2023 Cisco and/or its affiliates.
 //
@@ -78,6 +78,7 @@ func setupVeth(ctx context.Context, logger log.Logger, conn *networkservice.Conn
 		if err := createInterfaces(contIfName, hostIfName); err != nil {
 			return err
 		}
+		logger.Debugf("Interface %s created, peername: %s", contIfName, hostIfName)
 		if err := SetInterfacesUp(logger, contIfName, hostIfName); err != nil {
 			return err
 		}
@@ -111,7 +112,7 @@ func setupVeth(ctx context.Context, logger log.Logger, conn *networkservice.Conn
 	return nil
 }
 
-func resetVeth(ctx context.Context, logger log.Logger, conn *networkservice.Connection, bridgeName string,
+func resetVeth(logger log.Logger, conn *networkservice.Connection, bridgeName string,
 	parentIfRefCountMap map[string]int, serviceToparentIfMap map[string]string, isL2Connect, isClient bool) error {
 	var mechanism *kernel.Mechanism
 	if mechanism = kernel.ToMechanism(conn.GetMechanism()); mechanism == nil {
@@ -166,11 +167,10 @@ func resetVeth(ctx context.Context, logger log.Logger, conn *networkservice.Conn
 		if err := netlink.LinkDel(ifaceLink); err != nil {
 			return errors.Errorf("local: failed to delete the VETH pair - %v", err)
 		}
+		logger.Debugf("Interface %s deleted", ifaceName)
 		delete(parentIfRefCountMap, ifaceName)
 		delete(serviceToparentIfMap, serviceName)
 	}
-
-	vfconfig.Delete(ctx, isClient)
 	return nil
 }
 

--- a/pkg/networkservice/mechanisms/kernel/veth_server.go
+++ b/pkg/networkservice/mechanisms/kernel/veth_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Nordix Foundation.
+// Copyright (c) 2021-2023 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -58,7 +58,7 @@ func (k *kernelVethServer) Request(ctx context.Context, request *networkservice.
 	if !isEstablished {
 		k.parentIfmutex.Lock()
 		if err := setupVeth(ctx, logger, request.GetConnection(), k.bridgeName, k.parentIfRefCountMap, k.serviceToparentIfMap, metadata.IsClient(k)); err != nil {
-			_ = resetVeth(ctx, logger, request.GetConnection(), k.bridgeName, k.parentIfRefCountMap, k.serviceToparentIfMap, false, metadata.IsClient(k))
+			_ = resetVeth(logger, request.GetConnection(), k.bridgeName, k.parentIfRefCountMap, k.serviceToparentIfMap, false, metadata.IsClient(k))
 			k.parentIfmutex.Unlock()
 			return nil, err
 		}
@@ -72,7 +72,7 @@ func (k *kernelVethServer) Request(ctx context.Context, request *networkservice.
 		defer cancelClose()
 		if _, exists := ifnames.LoadAndDelete(closeCtx, metadata.IsClient(k)); exists {
 			k.parentIfmutex.Lock()
-			if kernelServerErr := resetVeth(closeCtx, logger, request.GetConnection(), k.bridgeName, k.parentIfRefCountMap, k.serviceToparentIfMap, false, metadata.IsClient(k)); kernelServerErr != nil {
+			if kernelServerErr := resetVeth(logger, request.GetConnection(), k.bridgeName, k.parentIfRefCountMap, k.serviceToparentIfMap, false, metadata.IsClient(k)); kernelServerErr != nil {
 				err = errors.Wrapf(err, "connection closed with error: %s", kernelServerErr.Error())
 			}
 			k.parentIfmutex.Unlock()
@@ -93,7 +93,7 @@ func (k *kernelVethServer) Close(ctx context.Context, conn *networkservice.Conne
 		var kernelServerErr error
 		ovsPortInfo, exists := ifnames.LoadAndDelete(ctx, metadata.IsClient(k))
 		if exists {
-			kernelServerErr = resetVeth(ctx, logger, conn, k.bridgeName, k.parentIfRefCountMap, k.serviceToparentIfMap, ovsPortInfo.IsL2Connect, metadata.IsClient(k))
+			kernelServerErr = resetVeth(logger, conn, k.bridgeName, k.parentIfRefCountMap, k.serviceToparentIfMap, ovsPortInfo.IsL2Connect, metadata.IsClient(k))
 		}
 		if err != nil && kernelServerErr != nil {
 			return nil, errors.Wrap(err, kernelServerErr.Error())


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->

The vfConfig structure deleted too early and the [inject](https://github.com/networkservicemesh/sdk-kernel/blob/253b41ce0fa537f190a43906a7ab12049cd593b4/pkg/kernel/networkservice/inject/common.go#L103) module can not find the information to delete the interface. 
Debug printouts added in cases when interface is added or deleted.

## Issue link
<!--- Please link to the issue here. -->
Related to: networkservicemesh/deployments-k8s#9778

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
