### PR TITLE
Delete ovs bridge when forwarder stop

### DIFF
--- a/pkg/tools/utils/ovs.go
+++ b/pkg/tools/utils/ovs.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 Nordix Foundation.
+// Copyright (c) 2021-2023 Nordix Foundation.
 //
 // Copyright (c) 2023 Cisco and/or its affiliates.
 //
@@ -106,6 +106,14 @@ func ConfigureOvS(ctx context.Context, l2Connections map[string]*L2ConnectionPoi
 	}
 
 	return nil
+}
+
+// DeleteBridge delete ovs bridge for client and endpoint connections
+func DeleteBridge(ctx context.Context, bridgeName string) {
+	stdout, stderr, err := util.RunOVSVsctl("del-br", bridgeName)
+	if err != nil {
+		log.FromContext(ctx).Warnf("Failed to remove bridge %s, stdout: %q, stderr: %q, error: %v", bridgeName, stdout, stderr, err)
+	}
 }
 
 func configureL2Interface(ctx context.Context, cp *L2ConnectionPoint) error {


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
Cleanup the bridge used to connect NSM endpoints.

## Issue link
<!--- Please link to the issue here. -->
Related issue: networkservicemesh/sdk-ovs#276

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->
Reproduction steps described in the issue
## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
