### PR TITLE
qfix: Use correct VxLAN port for the client/server cases

### DIFF
--- a/pkg/networkservice/mechanisms/vxlan/common.go
+++ b/pkg/networkservice/mechanisms/vxlan/common.go
@@ -56,14 +56,11 @@ func add(ctx context.Context, logger log.Logger, conn *networkservice.Connection
 		if !isClient {
 			egressIP = mechanism.DstIP()
 			remoteIP = mechanism.SrcIP()
+			port = mechanism.DstPort()
 		} else {
+			port = mechanism.SrcPort()
 			remoteIP = mechanism.DstIP()
 			egressIP = mechanism.SrcIP()
-		}
-		if !isClient {
-			port = mechanism.SrcPort()
-		} else {
-			port = mechanism.DstPort()
 		}
 		ovsTunnelName := getTunnelPortName(remoteIP.String())
 		vxlanInterfacesMutex.Lock()


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
Fixes ovs feature suite on the CI.
Root cause https://github.com/networkservicemesh/sdk-ovs/pull/303


## Issue link
Related to https://github.com/networkservicemesh/integration-k8s-kind/pull/995 


## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [X] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
